### PR TITLE
合并 Dev 分支更改，准备发布 1.2.3 版本

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Echo-Live 内置了多套主题，您可以通过修改 `live.html` 中定义主
 在 `live.html` 文件中您可用看到以下被注释强调的内容：
 
 ``` html
-<link rel="stylesheet" href="res/style/live-theme/vanilla.css">
+<link id="echo-live-theme" rel="stylesheet" href="res/style/live-theme/vanilla.css">
 ```
 
 假如您想将主题文件更换为 `bubble.css`，您应当如此修改：
 
 ``` html
-<link rel="stylesheet" href="res/style/live-theme/bubble.css">
+<link id="echo-live-theme" rel="stylesheet" href="res/style/live-theme/bubble.css">
 ```
 
 最后，别忘了保存文件。
@@ -120,6 +120,13 @@ extensionManager.load({
 - [如何为 Echo-Live 项目作出贡献？](CONTRIBUTING.md)
 - [授权协议与声明](copyright.md)
 - [GPL（GNU General Public License，GNU通用公共许可协议）第3版](LICENSE)
+
+### 姊妹项目
+- [Echo](https://github.com/sheep-realms/Echo)
+- [Echo-Live-Doc](https://github.com/sheep-realms/Echo-Live-Doc)
+
+### 第三方项目
+- [Echo-Live-Tauri](https://github.com/LuiScreaMed/Echo-Live-Tauri)
 - [Echo-Live-Typetool](https://github.com/RaySky-Rt/Echo-Live-Typetool)
 
 ## 相关资源

--- a/config.js
+++ b/config.js
@@ -81,6 +81,13 @@ const config = {
         tabpage_output_enable: true,
 
 
+        // 显示对话框状态仪表板
+        // * 仪表板可以显示所有对话框的状态，绿色为激活，红色为休眠，灰色则表示没有对话框加入频道。
+        // * 如果您添加了多个对话框，建议您启用此项。
+        // * 如果您是红绿色盲，请在下方无障碍相关配置中启用红绿色盲。
+        client_state_panel_enable: false,
+
+
         // == 表单预填充 ==
         // * 这些值会在页面初始化时被自动填充进表单中。
 
@@ -94,6 +101,13 @@ const config = {
         output_after: ');',
         // 启用上述功能，0 为禁用，1 为启用
         ontput_after_enable: 1,
+    },
+
+    // 无障碍相关配置
+    // * 编辑器支持键盘访问。
+    accessible: {
+        // 红绿色盲
+        color_blindness_red_green: false,
     }
 };
 

--- a/config.js
+++ b/config.js
@@ -85,6 +85,7 @@ const config = {
         // * 仪表板可以显示所有对话框的状态，绿色为激活，红色为休眠，灰色则表示没有对话框加入频道。
         // * 如果您添加了多个对话框，建议您启用此项。
         // * 如果您是红绿色盲，请在下方无障碍相关配置中启用红绿色盲。
+        // ** 启用后，蓝色填充为激活，蓝色边框为休眠。
         client_state_panel_enable: false,
 
 
@@ -107,7 +108,7 @@ const config = {
     // * 编辑器支持键盘访问。
     accessible: {
         // 红绿色盲
-        color_blindness_red_green: false,
+        drotanopia_and_deuteranopia: false,
     }
 };
 

--- a/config.js
+++ b/config.js
@@ -107,6 +107,8 @@ const config = {
     // 无障碍相关配置
     // * 编辑器支持键盘访问。
     accessible: {
+        // 高对比度
+        high_contrast: false,
         // 红绿色盲
         drotanopia_and_deuteranopia: false,
     }

--- a/editor.html
+++ b/editor.html
@@ -7,6 +7,7 @@
     <link rel="icon" href="res/image/favicon.ico">
     <link rel="stylesheet" href="res/style/fh-ui.css">
     <link rel="stylesheet" href="res/style/editor.css">
+    <link rel="stylesheet" href="res/style/editor-accessible.css">
     <script src="lib/jquery-1.7.2.min.js"></script>
     <script src="config.js"></script>
     <script src="res/class/EchoLiveBroadcast.js"></script>

--- a/editor.html
+++ b/editor.html
@@ -79,6 +79,13 @@
             <section class="tabpage-panel" role="tabpanel" data-pageid="ptext">
                 <h2 class="tabpage-panel-title">纯文本</h2>
                 <div class="echo-editor-from">
+                    <div class="echo-live-client-state hide">
+                        <label>对话框状态</label>
+                        <div class="echo-live-client-state-content">
+                            <div class="echo-live-client-state-block"></div>
+                        </div>
+                    </div>
+
                     <label for="character">说话人</label>
                     <input type="text" name="character" id="ptext-character">
 
@@ -333,7 +340,7 @@
             <!-- 日志标签页 -->
             <section class="tabpage-panel hide" role="tabpanel" data-pageid="log">
                 <h2 class="tabpage-panel-title">日志</h2>
-                <div id="editor-log">
+                <div id="editor-log" aria-label="这里是日志列表，如果您听到了这句话，请注意，这里的阅读体验可能会很差。">
                     
                 </div>
             </section>

--- a/live.html
+++ b/live.html
@@ -17,7 +17,7 @@
     <link rel="icon" href="res/image/favicon.ico">
 
     <!-- ↓ 这里是主题样式，如需替换请修改这里的 href 值 -->
-    <link rel="stylesheet" href="res/style/live-theme/vanilla.css">
+    <link id="echo-live-theme" rel="stylesheet" href="res/style/live-theme/vanilla.css">
     <!-- ↑ 这里是主题样式，请通过 res/style/live-theme/ 文件夹浏览可用主题 -->
 
     <link rel="stylesheet" href="res/style/echo.css">

--- a/res/class/Echo.js
+++ b/res/class/Echo.js
@@ -116,7 +116,7 @@ class Echo {
 
     messageSerialize(msg) {
         if (typeof msg == 'string') {
-            return msg.split('');
+            return [...msg];
         } else if (typeof msg == 'object' && msg != null) {
             let dataBefore = {
                 action: 'group_start',
@@ -135,9 +135,9 @@ class Echo {
 
             let dataContent, data;
             if (msg?.typewrite == undefined) {
-                dataContent = msg.text.split('');
+                dataContent = [...msg.text];
             } else {
-                dataContent = msg.typewrite.split('');
+                dataContent = [...msg.typewrite];
             }
 
             data = [dataBefore, ...dataContent, dataAfter];
@@ -184,8 +184,8 @@ class Echo {
         } else {
             if (typeof that.messageBuffer[0] == 'string') {
                 a = that.messageBuffer.shift();
-                // 中日韩字符跳过一回合
-                if (a.search(/[\u4e00-\u9fa5\u0800-\u4e00\uac00-\ud7ff]/) != -1 && that.typewrite == 'none') {
+                // 中日韩字符和辅助平面字符跳过一回合
+                if ((a.search(/[\u4e00-\u9fa5\u0800-\u4e00\uac00-\ud7ff]/) != -1 || a.codePointAt(0) >= 0x10000) && that.typewrite == 'none') {
                     that.dbChrBuffer = a;
                     return;
                 }
@@ -236,7 +236,7 @@ class Echo {
         this.event.send();
         this.message = text;
         if (typeof this.message == 'string') {
-            this.messageBuffer = text.split('');
+            this.messageBuffer = [...text];
         } else if (typeof this.message == 'object' && this.message != null) {
             if (Array.isArray(this.message)) {
                 this.message.forEach(e => {

--- a/res/class/EchoLive.js
+++ b/res/class/EchoLive.js
@@ -46,6 +46,10 @@ class EchoLive {
         }
     }
 
+    /**
+     * 发送消息
+     * @param {Object} data 消息格式
+     */
     send(data = {}) {
         if (this.hidden) return;
         if (this.antiFlood) {
@@ -60,6 +64,9 @@ class EchoLive {
         this.echo.sendList(JSON.parse(JSON.stringify(data.messages)));
     }
 
+    /**
+     * 下一条对话
+     */
     next() {
         if (this.hidden) return;
         this.echo.next();
@@ -83,6 +90,14 @@ class EchoLive {
 
     stop() {
         clearInterval(this.timer.messagesPolling);
+    }
+
+    /**
+     * 修改主题样式地址
+     * @param {String} url 样式文件地址
+     */
+    setThemeStyleUrl(url) {
+        $('#echo-live-theme').attr('href', url);
     }
 
     getUUID() {

--- a/res/class/EditorConstructor.js
+++ b/res/class/EditorConstructor.js
@@ -110,3 +110,33 @@ class EditorForm {
         );
     }
 }
+
+// 客户端状态仪表构造器
+class EditorClientState {
+    constructor() {}
+
+    static block(type, title = '') {
+        return `<div class="echo-live-client-state-block state-${type}" title="${title}"></div>`
+    }
+
+    static clientBlock(client) {
+        if (client.hidden) {
+            return EditorClientState.block('sleep', '休眠');
+        } else {
+            return EditorClientState.block('active', '激活');
+        }
+    }
+
+    static clientList(clients) {
+        if (clients.length == 0) return EditorClientState.block('none');
+        let dom = '';
+        clients.forEach(e => {
+            dom += EditorClientState.clientBlock(e);
+        });
+        return dom;
+    }
+
+    static statePanel(clients) {
+        return `<div class="echo-live-client-state-panel">${EditorClientState.clientList(clients)}</div>`;
+    }
+}

--- a/res/script/editor.js
+++ b/res/script/editor.js
@@ -17,7 +17,7 @@ setCheckboxDefaultValue('#config-output-use-after', config.editor.ontput_after_e
 if (!config.editor.tabpage_config_enable) $('#tabpage-nav-config').addClass('hide');
 if (!config.editor.tabpage_output_enable) $('#tabpage-nav-output').addClass('hide');
 
-if (config.accessible.color_blindness_red_green) $('body').addClass('accessible-color-blindness-red-green');
+if (config.accessible.drotanopia_and_deuteranopia) $('body').addClass('accessible-drotanopia-and-deuteranopia');
 
 let elb;
 

--- a/res/script/editor.js
+++ b/res/script/editor.js
@@ -17,6 +17,7 @@ setCheckboxDefaultValue('#config-output-use-after', config.editor.ontput_after_e
 if (!config.editor.tabpage_config_enable) $('#tabpage-nav-config').addClass('hide');
 if (!config.editor.tabpage_output_enable) $('#tabpage-nav-output').addClass('hide');
 
+if (config.accessible.high_contrast)  $('body').addClass('accessible-high-contrast');
 if (config.accessible.drotanopia_and_deuteranopia) $('body').addClass('accessible-drotanopia-and-deuteranopia');
 
 let elb;

--- a/res/script/editor.js
+++ b/res/script/editor.js
@@ -17,6 +17,8 @@ setCheckboxDefaultValue('#config-output-use-after', config.editor.ontput_after_e
 if (!config.editor.tabpage_config_enable) $('#tabpage-nav-config').addClass('hide');
 if (!config.editor.tabpage_output_enable) $('#tabpage-nav-output').addClass('hide');
 
+if (config.accessible.color_blindness_red_green) $('body').addClass('accessible-color-blindness-red-green');
+
 let elb;
 
 if (config.echo.print_speed != 30) {
@@ -29,6 +31,11 @@ if (config.echolive.broadcast_enable) {
     $('#ptext-btn-submit').addClass('fh-ghost');
     $('#ptext-btn-send').removeClass('hide');
     $('#ptext-content').attr('title', '当焦点在此文本框中时，可用按下 Ctrl + Enter 快速发送');
+
+    if (config.editor.client_state_panel_enable) {
+        $('.echo-live-client-state').removeClass('hide');
+    }
+
     // 纯文本 - 内容 - 快捷键
     $('#ptext-content').keydown(function(e) {
         if (e.keyCode == 13 && e.ctrlKey) {
@@ -44,7 +51,10 @@ if (config.echolive.broadcast_enable) {
         }
     })
 
+    $('.echo-live-client-state-content').html(EditorClientState.statePanel([]));
+
     elb = new EchoLiveBroadcast(undefined, config.echolive.broadcast_channel);
+    elb.on('clientsChange', clientsChange);
     elb.on('message', getMessage);
     elb.on('noClient', noClient);
 
@@ -78,7 +88,15 @@ function afterZero(value) {
 let logMsgMark = 0;
 
 function editorLog(message = '', type = 'info') {
-    $('#editor-log').append(`<div class="log-item log-type-${type}"><span class="time">${getTime()}</span> <span class="type">[${type.toUpperCase()}]</span> <span class="message">${message}</span></div>`);
+    const typename = {
+        'dbug': '调试：',
+        'tips': '提示：',
+        'info': '信息：',
+        'warn': '警告：',
+        'erro': '错误：',
+        'done': '完成：',
+    };
+    $('#editor-log').append(`<div class="log-item log-type-${type}" ${type == 'dbug' ? 'aria-hidden="false"' : ''}><span class="time" aria-hidden="false">${getTime()}</span> <span class="type" aria-label="${typename[type]}">[${type.toUpperCase()}]</span> <span class="message">${message}</span></div>`);
     $('#editor-log').scrollTop($('#editor-log').height());
 
     if ((type == 'warn' || type == 'error') && $('#tabpage-nav-log').attr('aria-selected') == 'false') {
@@ -92,6 +110,10 @@ $('#tabpage-nav-log').click(function() {
     logMsgMark = 0;
     $('#log-message-mark').addClass('hide');
 });
+
+function clientsChange (e) {
+    $('.echo-live-client-state-content').html(EditorClientState.statePanel(e));
+}
 
 function getMessage(data) {
     switch (data.action) {

--- a/res/script/live.js
+++ b/res/script/live.js
@@ -24,7 +24,7 @@ echo.on('print', function(chr) {
         $(`.echo-output span[data-group="${gruopIndex}"]`).append(chr);
     }
 
-    if (config.echolive.print_audio_enable && chr != '' && printSe) {
+    if (config.echolive.print_audio_enable && chr != '' && chr != undefined && printSe) {
         mixer.play(config.echolive.print_audio_name, config.echolive.print_audio_volume, config.echolive.print_audio_rate);
         // 打印音效稳定器
         printSe = false;

--- a/res/style/editor-accessible.css
+++ b/res/style/editor-accessible.css
@@ -1,0 +1,53 @@
+/* 高对比度 */
+.accessible-high-contrast {
+    --color-main: rgb(44, 114, 154);
+    --color-main-dark: gb(26, 90, 127);
+
+    --color-general: rgb(44, 114, 154);
+    --color-safe: rgb(50, 141, 42);
+    --color-warn: rgb(148, 122, 35);
+    --color-danger: rgb(148, 56, 60);
+    --color-special: rgb(114, 56, 135);
+
+    --color-general-dark: rgb(26, 90, 127);
+    --color-safe-dark: rgb(34, 94, 27);
+    --color-warn-dark: rgb(112, 94, 33);
+    --color-danger-dark: rgb(128, 41, 46);
+    --color-special-dark: rgb(91, 37, 110);
+
+    --color-general-glass: rgba(45, 147, 206, 0.05);
+    --color-safe-glass: rgba(69, 204, 56, 0.05);
+    --color-warn-glass: rgba(230, 189, 53, 0.05);
+    --color-danger-glass: rgba(230, 82, 89, 0.05);
+    --color-special-glass: rgba(147, 61, 178, 0.05);
+
+    --text-primary: #000;
+    --text-regular: #222;
+    --text-secondary: #444;
+    --text-placeholder: #666;
+
+    --border-coler: #000;
+}
+
+.accessible-high-contrast .echo-live-client-state-block.state-sleep {
+    background-color: transparent;
+    border: 1px solid var(--color-danger-dark);
+}
+
+.accessible-high-contrast textarea,
+.accessible-high-contrast input[type=number],
+.accessible-high-contrast input[type=text],
+.accessible-high-contrast #editor-log {
+    border: 1px solid var(--text-primary);
+}
+
+
+/* 红绿色盲 */
+.accessible-drotanopia-and-deuteranopia .echo-live-client-state-block.state-active {
+    background-color: var(--color-general-dark);
+}
+
+.accessible-drotanopia-and-deuteranopia .echo-live-client-state-block.state-sleep {
+    background-color: transparent;
+    border: 1px solid var(--color-general-dark);
+}

--- a/res/style/editor.css
+++ b/res/style/editor.css
@@ -56,7 +56,8 @@ textarea.code {
 .tabpage-nav-item.hide,
 .collapse-content.hide,
 .print-speed-change.hide,
-#log-message-mark.hide {
+#log-message-mark.hide,
+.echo-live-client-state.hide {
     display: none;
 }
 
@@ -370,4 +371,37 @@ input[type=text]:focus {
         padding-left: 0;
         text-indent: 0;
     }
+}
+
+.echo-live-client-state {
+    margin-bottom: 8px;
+}
+
+.echo-live-client-state-panel {
+    display: flex;
+    gap: 4px;
+}
+
+.echo-live-client-state-block {
+    background-color: #EEEEEE;
+    height: 8px;
+    flex: 1;
+    box-sizing: border-box;
+}
+
+.echo-live-client-state-block.state-active {
+    background-color: var(--color-safe-dark);
+}
+
+.echo-live-client-state-block.state-sleep {
+    background-color: var(--color-danger-dark);
+}
+
+.accessible-color-blindness-red-green .echo-live-client-state-block.state-active {
+    background-color: var(--color-general-dark);
+}
+
+.accessible-color-blindness-red-green .echo-live-client-state-block.state-sleep {
+    background-color: transparent;
+    border: 1px solid var(--color-general-dark);
 }

--- a/res/style/editor.css
+++ b/res/style/editor.css
@@ -2,11 +2,15 @@
     margin: 0;
     padding: 0;
     font-family: '思源黑体', 'Microsoft YaHei', sans-serif;
+}
 
+:root {
     --text-primary: #303133;
     --text-regular: #606266;
     --text-secondary: #909399;
     --text-placeholder: #a8abb2;
+
+    --border-coler: #AAAAAA;
 }
 
 body {
@@ -23,7 +27,7 @@ textarea.code {
 }
 
 .tabpage-nav {
-    border-bottom: #AAAAAA 1px solid;
+    border-bottom: var(--border-coler) 1px solid;
     display: flex;
     margin-bottom: 16px;
     --corner-marker-color: rgba(0, 0, 0, 0.25);
@@ -83,7 +87,7 @@ textarea.code {
     box-sizing: border-box;
     padding: 0.5em;
     border: unset;
-    border-bottom: #AAAAAA 1px solid;
+    border-bottom: var(--border-coler) 1px solid;
     outline: none;
     background-color: #FFFFFF;
     transition: border .3s;
@@ -96,7 +100,7 @@ textarea.code {
 .editor-controller-bottom {
     padding: 16px 0;
     margin-top: -1px;
-    border-top: #AAAAAA 1px solid;
+    border-top: var(--border-coler) 1px solid;
     position: sticky;
     bottom: 0;
     background-color: #FAFAFA;
@@ -116,12 +120,12 @@ textarea.code {
 }
 
 .collapse-title {
-    border-bottom: #AAAAAA 1px solid;
+    border-bottom: var(--border-coler) 1px solid;
     display: flex;
 }
 
 .collapse-content {
-    border-bottom: #AAAAAA 1px solid;
+    border-bottom: var(--border-coler) 1px solid;
 }
 
 .collapse-title button {
@@ -237,7 +241,7 @@ input[type=text] {
     box-sizing: border-box;
     padding: 0.25em 0.5em;
     border: unset;
-    border-bottom: #AAAAAA 1px solid;
+    border-bottom: var(--border-coler) 1px solid;
     outline: none;
     background-color: #FFFFFF;
     transition: border .3s;
@@ -275,7 +279,7 @@ input[type=text]:focus {
 .editor-text-list-item {
     display: flex;
     align-items: center;
-    border-bottom: #AAAAAA 1px solid;
+    border-bottom: var(--border-coler) 1px solid;
     padding: 0.25em 0;
     justify-content: space-between;
 }
@@ -395,13 +399,4 @@ input[type=text]:focus {
 
 .echo-live-client-state-block.state-sleep {
     background-color: var(--color-danger-dark);
-}
-
-.accessible-drotanopia_and_deuteranopia .echo-live-client-state-block.state-active {
-    background-color: var(--color-general-dark);
-}
-
-.accessible-drotanopia_and_deuteranopia .echo-live-client-state-block.state-sleep {
-    background-color: transparent;
-    border: 1px solid var(--color-general-dark);
 }

--- a/res/style/editor.css
+++ b/res/style/editor.css
@@ -397,11 +397,11 @@ input[type=text]:focus {
     background-color: var(--color-danger-dark);
 }
 
-.accessible-color-blindness-red-green .echo-live-client-state-block.state-active {
+.accessible-drotanopia_and_deuteranopia .echo-live-client-state-block.state-active {
     background-color: var(--color-general-dark);
 }
 
-.accessible-color-blindness-red-green .echo-live-client-state-block.state-sleep {
+.accessible-drotanopia_and_deuteranopia .echo-live-client-state-block.state-sleep {
     background-color: transparent;
     border: 1px solid var(--color-general-dark);
 }

--- a/res/style/fh-ui.css
+++ b/res/style/fh-ui.css
@@ -2,6 +2,13 @@
     margin: 0;
     padding: 0;
 
+    --corner-marker-color: rgba(255,255,255,0.5);
+    --corner-marker-angle: -135deg;
+    --corner-marker-angle-reverse: 45deg;
+    --corner-marker: linear-gradient(var(--corner-marker-angle), var(--corner-marker-color) 5px, transparent 5px);
+}
+
+:root {
     --color-main: rgb(64, 173, 235);
     --color-main-dark: rgb(40, 144, 204);
 
@@ -22,11 +29,6 @@
     --color-warn-glass: rgba(230, 189, 53, 0.12);
     --color-danger-glass: rgba(230, 82, 89, 0.12);
     --color-special-glass: rgba(147, 61, 178, 0.12);
-
-    --corner-marker-color: rgba(255,255,255,0.5);
-    --corner-marker-angle: -135deg;
-    --corner-marker-angle-reverse: 45deg;
-    --corner-marker: linear-gradient(var(--corner-marker-angle), var(--corner-marker-color) 5px, transparent 5px);
 
     --color-msgbox-background: #EEE;
 


### PR DESCRIPTION
## 新增
- 编辑器新增对话框状态仪表板，绿色为激活，红色为休眠，灰色则表示没有对话框加入频道。
  - 新增配置项 `client_state_panel_enable` 用于启用仪表板，默认关闭。
- 新增配置项 `accessible.high_contrast` 和 `accessible.drotanopia_and_deuteranopia`，用于为编辑器开启高对比度样式和红绿色盲样式。
- `EchoLive` 新增 `setThemeStyleUrl` 方法用于动态修改主题样式文件地址。（未使用）

## 更改
- Unicode 辅助平面字符现在和中日韩统一表意文字一样使用两个打印循环。
- 修改了 `EchoLiveBroadcast` 类 `clients` 属性的格式。

## 修复
- 空消息会触发一次打印音效。
- #6 - Emoji 等 Unicode 辅助平面字符会被分割打印。